### PR TITLE
Variable number of args in UDFs

### DIFF
--- a/partners/typescript/alasql.d.ts
+++ b/partners/typescript/alasql.d.ts
@@ -49,7 +49,7 @@ declare namespace alaSQLSpace {
 
     // see https://github.com/agershun/alasql/wiki/User%20Defined%20Functions
     interface userDefinedFunction {
-        (x: any): any;
+        (...x: any[]): any;
     }
     interface userDefinedFunctionLookUp {
         [x: string]: userDefinedFunction;


### PR DESCRIPTION
AlaSQL supports multiple arguments in a UDF but the types need to be updated to reflect the exposed API.